### PR TITLE
Raise exception if no valid ID is given for serialization

### DIFF
--- a/src/Doctrine/QueueableEntityNormalizer.php
+++ b/src/Doctrine/QueueableEntityNormalizer.php
@@ -56,7 +56,7 @@ class QueueableEntityNormalizer extends AbstractAggregateNormalizerAware impleme
      */
     public function denormalize($data, $class, $format = null, array $context = array())
     {
-        if (!empty($data['id'])) {
+        if (empty($data['id']) || empty($data['class'])) {
             return null;
         }
 

--- a/src/Doctrine/QueueableEntityNormalizer.php
+++ b/src/Doctrine/QueueableEntityNormalizer.php
@@ -56,8 +56,8 @@ class QueueableEntityNormalizer extends AbstractAggregateNormalizerAware impleme
      */
     public function denormalize($data, $class, $format = null, array $context = array())
     {
-        if (!array_key_exists('id', $data) || is_null($data['id'])) {
-            throw new InvalidArgumentException('Entity lacks of an id for deserialization');
+        if (!empty($data['id'])) {
+            return null;
         }
 
         return $this->entityManager->getReference($data['class'], $data['id']);

--- a/src/Doctrine/QueueableEntityNormalizer.php
+++ b/src/Doctrine/QueueableEntityNormalizer.php
@@ -6,6 +6,7 @@ use Workana\AsyncJobs\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use InvalidArgumentException;
 
 /**
  * @author Carlos Frutos <charly@workana.com>
@@ -32,6 +33,10 @@ class QueueableEntityNormalizer extends AbstractAggregateNormalizerAware impleme
      */
     public function normalize($object, $format = null, array $context = array())
     {
+        if (is_null($object->getId())) {
+            throw new InvalidArgumentException('Entity lacks of a valid id for serialization (has been persisted yet?)');
+        }
+
         return [
             'class' => ClassUtils::getRealClass($object),
             'id' => $object->getId(),
@@ -51,6 +56,10 @@ class QueueableEntityNormalizer extends AbstractAggregateNormalizerAware impleme
      */
     public function denormalize($data, $class, $format = null, array $context = array())
     {
+        if (!array_key_exists('id', $data) || is_null($data['id'])) {
+            throw new InvalidArgumentException('Entity lacks of an id for deserialization');
+        }
+
         return $this->entityManager->getReference($data['class'], $data['id']);
     }
 


### PR DESCRIPTION
When an unpersisted entity is normalized now we raise an exception if no id is present. This prevents serialization of unsaved entities with null ids that pose a risk of an invalid serialized state.