### PR TITLE
Support for overriding Gedmo soft deleted entities de-normalization

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -24,6 +24,7 @@ class Configuration
             'normalizerClasses' => [],
             'defaultQueueName' => 'default',
             'useDoctrine' => false,
+            'enableGedmoSoftDeleteBehaviour' => true,
             'sync' => false,
             'dispatchingRules' => [],
         ];
@@ -97,6 +98,14 @@ class Configuration
     public function isUsingDoctrine()
     {
         return $this->attributes['useDoctrine'];
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabledGedmoSoftDeleteBehaviour()
+    {
+        return $this->attributes['enableGedmoSoftDeleteBehaviour'];
     }
 
     /**


### PR DESCRIPTION
Add functionality for overriding gedmo soft-delete filters when hydrating entities using `QueueableEntityNormalizer`.

Proposed target version: `1.2.1`