### PR TITLE
Fix for symfony console warning

### DIFF
--- a/src/Console/ConsumeCommand.php
+++ b/src/Console/ConsumeCommand.php
@@ -58,5 +58,7 @@ class ConsumeCommand extends Command
 
         $worker = $this->jm->createWorkerBuilder()->usingMultipleQueues($queues)->build();
         $worker->run();
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Console/PingCommand.php
+++ b/src/Console/PingCommand.php
@@ -62,5 +62,7 @@ class PingCommand extends Command
 
             $output->writeln('Ping sent to: ' . $queueName);
         }
+
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
Fixes for new Console version type check:

```
Uncaught Exception TypeError: "Return value of "Workana\AsyncJobs\Console\ConsumeCommand::execute()" must be of the type int, "null" returned." symfony/console/Command/Command.php line 259
```